### PR TITLE
Switch order of literals to prevent NullPointerException (#4)

### DIFF
--- a/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VodActivity.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/activity/VodActivity.java
@@ -190,7 +190,7 @@ public class VodActivity extends BaseActivity implements TypePresenter.OnClickLi
         @Override
         public Fragment getItem(int position) {
             Class type = (Class) mAdapter.get(position);
-            return VodFragment.newInstance(getKey(), type.getTypeId(), type.getStyle(), type.getExtend(false), type.getTypeFlag().equals("1"));
+            return VodFragment.newInstance(getKey(), type.getTypeId(), type.getStyle(), type.getExtend(false), "1".equals(type.getTypeFlag()));
         }
 
         @Override

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ConfigDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ConfigDialog.java
@@ -123,13 +123,13 @@ public class ConfigDialog implements DialogInterface.OnDismissListener {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("h")) {
+        if (append && "h".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ttp://");
-        } else if (append && s.equalsIgnoreCase("f")) {
+        } else if (append && "f".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ile://");
-        } else if (append && s.equalsIgnoreCase("a")) {
+        } else if (append && "a".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ssets://");
         } else if (s.length() > 1) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ProxyDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/ProxyDialog.java
@@ -84,10 +84,10 @@ public class ProxyDialog implements DialogInterface.OnDismissListener {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("h")) {
+        if (append && "h".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ttp://");
-        } else if (append && s.equalsIgnoreCase("s")) {
+        } else if (append && "s".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ocks5://");
         } else if (append && s.length() == 1) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/UaDialog.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/dialog/UaDialog.java
@@ -85,10 +85,10 @@ public class UaDialog implements DialogInterface.OnDismissListener {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("c")) {
+        if (append && "c".equalsIgnoreCase(s)) {
             append = false;
             binding.text.setText(Util.CHROME);
-        } else if (append && s.equalsIgnoreCase("o")) {
+        } else if (append && "o".equalsIgnoreCase(s)) {
             append = false;
             binding.text.setText(okhttp3.internal.Util.userAgent);
         } else if (s.length() > 1) {

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/CollectFragment.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/CollectFragment.java
@@ -128,7 +128,7 @@ public class CollectFragment extends BaseFragment implements CustomScroller.Call
 
     @Override
     public void onLoadMore(String page) {
-        if (mCollect == null || mCollect.getSite().getKey().equals("all")) return;
+        if (mCollect == null || "all".equals(mCollect.getSite().getKey())) return;
         mViewModel.searchContent(mCollect.getSite(), getKeyword(), page);
         mScroller.setLoading(true);
     }

--- a/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
+++ b/app/src/leanback/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
@@ -171,7 +171,7 @@ public class VodFragment extends BaseFragment implements CustomScroller.Callback
     }
 
     private void getVideo(String typeId, String page) {
-        boolean first = page.equals("1");
+        boolean first = "1".equals(page);
         if (first) mLast = null;
         if (first) showProgress();
         int filterSize = mOpen ? mFilters.size() : 0;

--- a/app/src/main/java/com/fongmi/android/tv/api/config/VodConfig.java
+++ b/app/src/main/java/com/fongmi/android/tv/api/config/VodConfig.java
@@ -249,9 +249,9 @@ public class VodConfig {
     }
 
     public Object[] proxyLocal(Map<String, String> params) {
-        if (params.containsKey("do") && params.get("do").equals("js")) {
+        if (params.containsKey("do") && "js".equals(params.get("do"))) {
             return jsLoader.proxyInvoke(params);
-        } else if (params.containsKey("do") && params.get("do").equals("py")) {
+        } else if (params.containsKey("do") && "py".equals(params.get("do"))) {
             return pyLoader.proxyInvoke(params);
         } else {
             return jarLoader.proxyInvoke(params);

--- a/app/src/main/java/com/fongmi/android/tv/bean/Class.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Class.java
@@ -121,7 +121,7 @@ public class Class implements Parcelable {
     }
 
     public boolean isHome() {
-        return getTypeId().equals("home");
+        return "home".equals(getTypeId());
     }
 
     public void trans() {

--- a/app/src/main/java/com/fongmi/android/tv/bean/Style.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Style.java
@@ -51,15 +51,15 @@ public class Style implements Parcelable {
     }
 
     public boolean isRect() {
-        return getType().equals("rect");
+        return "rect".equals(getType());
     }
 
     public boolean isOval() {
-        return getType().equals("oval");
+        return "oval".equals(getType());
     }
 
     public boolean isList() {
-        return getType().equals("list");
+        return "list".equals(getType());
     }
 
     public boolean isLand() {

--- a/app/src/main/java/com/fongmi/android/tv/bean/Vod.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Vod.java
@@ -228,11 +228,11 @@ public class Vod implements Parcelable {
     }
 
     public boolean isFolder() {
-        return getVodTag().equals("folder") || getCate() != null;
+        return "folder".equals(getVodTag()) || getCate() != null;
     }
 
     public boolean isManga() {
-        return getVodTag().equals("manga");
+        return "manga".equals(getVodTag());
     }
 
     public Style getStyle(Style style) {

--- a/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
+++ b/app/src/main/java/com/fongmi/android/tv/model/SiteViewModel.java
@@ -125,7 +125,7 @@ public class SiteViewModel extends ViewModel {
                 if (!result.getList().isEmpty()) result.getList().get(0).setVodFlags();
                 if (!result.getList().isEmpty()) checkThunder(result.getList().get(0).getVodFlags());
                 return result;
-            } else if (site.isEmpty() && key.equals("push_agent")) {
+            } else if (site.isEmpty() && "push_agent".equals(key)) {
                 Vod vod = new Vod();
                 vod.setVodId(id);
                 vod.setVodName(id);
@@ -173,7 +173,7 @@ public class SiteViewModel extends ViewModel {
                 result.setUrl(Source.get().fetch(result));
                 result.setHeader(site.getHeader());
                 return result;
-            } else if (site.isEmpty() && key.equals("push_agent")) {
+            } else if (site.isEmpty() && "push_agent".equals(key)) {
                 Result result = new Result();
                 result.setParse(0);
                 result.setFlag(flag);
@@ -183,7 +183,7 @@ public class SiteViewModel extends ViewModel {
             } else {
                 Url url = Url.create().add(id);
                 String type = Uri.parse(id).getQueryParameter("type");
-                if (type != null && type.equals("json")) url = Result.fromJson(OkHttp.newCall(id, site.getHeaders()).execute().body().string()).getUrl();
+                if (type != null && "json".equals(type)) url = Result.fromJson(OkHttp.newCall(id, site.getHeaders()).execute().body().string()).getUrl();
                 Result result = new Result();
                 result.setUrl(url);
                 result.setFlag(flag);

--- a/app/src/main/java/com/fongmi/android/tv/player/ParseJob.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/ParseJob.java
@@ -188,7 +188,7 @@ public class ParseJob implements ParseCallback {
 
     private Map<String, String> getHeader(JsonObject object) {
         Map<String, String> headers = new HashMap<>();
-        for (String key : object.keySet()) if (key.equalsIgnoreCase(HttpHeaders.USER_AGENT) || key.equalsIgnoreCase(HttpHeaders.REFERER)) headers.put(UrlUtil.fixHeader(key), object.get(key).getAsString());
+        for (String key : object.keySet()) if (HttpHeaders.USER_AGENT.equalsIgnoreCase(key) || HttpHeaders.REFERER.equalsIgnoreCase(key)) headers.put(UrlUtil.fixHeader(key), object.get(key).getAsString());
         if (headers.isEmpty()) return parse.getHeaders();
         return headers;
     }

--- a/app/src/main/java/com/fongmi/android/tv/player/Players.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/Players.java
@@ -565,13 +565,13 @@ public class Players implements Player.Listener, IMediaPlayer.Listener, Analytic
         Uri uri = UrlUtil.uri(url);
         String host = UrlUtil.host(uri);
         String scheme = UrlUtil.scheme(uri);
-        if (scheme.equals("data")) return false;
-        return scheme.isEmpty() || scheme.equals("file") ? !Path.exists(url) : host.isEmpty();
+        if ("data".equals(scheme)) return false;
+        return scheme.isEmpty() || "file".equals(scheme) ? !Path.exists(url) : host.isEmpty();
     }
 
     public static Map<String, String> checkUa(Map<String, String> headers) {
         if (Setting.getUa().isEmpty()) return headers;
-        for (Map.Entry<String, String> header : headers.entrySet()) if (header.getKey().equalsIgnoreCase(HttpHeaders.USER_AGENT)) return headers;
+        for (Map.Entry<String, String> header : headers.entrySet()) if (HttpHeaders.USER_AGENT.equalsIgnoreCase(header.getKey())) return headers;
         headers.put(HttpHeaders.USER_AGENT, Setting.getUa());
         return headers;
     }
@@ -581,8 +581,8 @@ public class Players implements Player.Listener, IMediaPlayer.Listener, Analytic
             if (data == null || data.getExtras() == null) return;
             int position = data.getExtras().getInt("position", 0);
             String endBy = data.getExtras().getString("end_by", "");
-            if (endBy.equals("playback_completion")) ActionEvent.next();
-            if (endBy.equals("user")) seekTo(position, true);
+            if ("playback_completion".equals(endBy)) ActionEvent.next();
+            if ("user".equals(endBy)) seekTo(position, true);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/Force.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/Force.java
@@ -23,7 +23,7 @@ public class Force implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return !scheme.equals("push") && scheme.startsWith("p") || scheme.equals("mitv");
+        return !"push".equals(scheme) && scheme.startsWith("p") || "mitv".equals(scheme);
     }
 
     private void init(String scheme) {

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/JianPian.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/JianPian.java
@@ -16,7 +16,7 @@ public class JianPian implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("tvbox-xg") || scheme.equals("jianpian") || scheme.equals("ftp");
+        return "tvbox-xg".equals(scheme) || "jianpian".equals(scheme) || "ftp".equals(scheme);
     }
 
     private void init() {

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/Push.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/Push.java
@@ -10,7 +10,7 @@ public class Push implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("push");
+        return "push".equals(scheme);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/TVBus.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/TVBus.java
@@ -18,7 +18,7 @@ public class TVBus implements Source.Extractor, Listener {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("tvbus");
+        return "tvbus".equals(scheme);
     }
 
     private void init(Core core) {

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/Thunder.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/Thunder.java
@@ -21,7 +21,7 @@ public class Thunder implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("magnet") || scheme.equals("ed2k");
+        return "magnet".equals(scheme) || "ed2k".equals(scheme);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/Video.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/Video.java
@@ -6,7 +6,7 @@ public class Video implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("video");
+        return "video".equals(scheme);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/player/extractor/ZLive.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/extractor/ZLive.java
@@ -24,7 +24,7 @@ public class ZLive implements Source.Extractor {
 
     @Override
     public boolean match(String scheme, String host) {
-        return scheme.equals("zlive");
+        return "zlive".equals(scheme);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/server/process/Action.java
+++ b/app/src/main/java/com/fongmi/android/tv/server/process/Action.java
@@ -30,7 +30,7 @@ public class Action implements Process {
 
     @Override
     public boolean isRequest(NanoHTTPD.IHTTPSession session, String path) {
-        return path.equals("/action");
+        return "/action".equals(path);
     }
 
     @Override

--- a/app/src/main/java/com/fongmi/android/tv/server/process/Cache.java
+++ b/app/src/main/java/com/fongmi/android/tv/server/process/Cache.java
@@ -14,7 +14,7 @@ public class Cache implements Process {
 
     @Override
     public boolean isRequest(NanoHTTPD.IHTTPSession session, String path) {
-        return path.equals("/cache");
+        return "/cache".equals(path);
     }
 
     private String getKey(String rule, String key) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWebView.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/custom/CustomWebView.java
@@ -80,7 +80,7 @@ public class CustomWebView extends WebView {
         if (headers.isEmpty()) {
             getSettings().setUserAgentString(Setting.getUa());
         } else for (String key : headers.keySet()) {
-            if (key.equalsIgnoreCase(HttpHeaders.USER_AGENT)) {
+            if (HttpHeaders.USER_AGENT.equalsIgnoreCase(key)) {
                 getSettings().setUserAgentString(headers.get(key));
                 break;
             }

--- a/app/src/main/java/com/fongmi/android/tv/utils/M3U8.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/M3U8.java
@@ -69,7 +69,7 @@ public class M3U8 {
 
     private static Headers getHeader(Map<String, String> headers) {
         Headers.Builder builder = new Headers.Builder();
-        for (Map.Entry<String, String> header : headers.entrySet()) if (header.getKey().equalsIgnoreCase(HttpHeaders.USER_AGENT) || header.getKey().equalsIgnoreCase(HttpHeaders.REFERER) || header.getKey().equalsIgnoreCase(HttpHeaders.COOKIE)) builder.add(header.getKey(), header.getValue());
+        for (Map.Entry<String, String> header : headers.entrySet()) if (HttpHeaders.USER_AGENT.equalsIgnoreCase(header.getKey()) || HttpHeaders.REFERER.equalsIgnoreCase(header.getKey()) || HttpHeaders.COOKIE.equalsIgnoreCase(header.getKey())) builder.add(header.getKey(), header.getValue());
         builder.add(HttpHeaders.RANGE, "bytes=0-");
         return builder.build();
     }

--- a/app/src/main/java/com/fongmi/android/tv/utils/UrlUtil.java
+++ b/app/src/main/java/com/fongmi/android/tv/utils/UrlUtil.java
@@ -44,9 +44,9 @@ public class UrlUtil {
     }
 
     public static String fixHeader(String key) {
-        if (key.equalsIgnoreCase(HttpHeaders.USER_AGENT)) return HttpHeaders.USER_AGENT;
-        if (key.equalsIgnoreCase(HttpHeaders.REFERER)) return HttpHeaders.REFERER;
-        if (key.equalsIgnoreCase(HttpHeaders.COOKIE)) return HttpHeaders.COOKIE;
+        if (HttpHeaders.USER_AGENT.equalsIgnoreCase(key)) return HttpHeaders.USER_AGENT;
+        if (HttpHeaders.REFERER.equalsIgnoreCase(key)) return HttpHeaders.REFERER;
+        if (HttpHeaders.COOKIE.equalsIgnoreCase(key)) return HttpHeaders.COOKIE;
         return key;
     }
 }

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/CollectActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/CollectActivity.java
@@ -285,7 +285,7 @@ public class CollectActivity extends BaseActivity implements CustomScroller.Call
     @Override
     public void onLoadMore(String page) {
         Collect activated = mCollectAdapter.getActivated();
-        if (activated.getSite().getKey().equals("all")) return;
+        if ("all".equals(activated.getSite().getKey())) return;
         mViewModel.searchContent(activated.getSite(), mBinding.keyword.getText().toString(), page);
         activated.setPage(Integer.parseInt(page));
         mScroller.setLoading(true);

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/activity/FolderActivity.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/activity/FolderActivity.java
@@ -45,7 +45,7 @@ public class FolderActivity extends BaseActivity {
         Result result = getResult();
         Class type = result.getTypes().get(0);
         mBinding.text.setText(type.getTypeName());
-        getSupportFragmentManager().beginTransaction().replace(R.id.container, TypeFragment.newInstance(getKey(), type.getTypeId(), type.getStyle(), new HashMap<>(), type.getTypeFlag().equals("1")), "0").commitAllowingStateLoss();
+        getSupportFragmentManager().beginTransaction().replace(R.id.container, TypeFragment.newInstance(getKey(), type.getTypeId(), type.getStyle(), new HashMap<>(), "1".equals(type.getTypeFlag())), "0").commitAllowingStateLoss();
     }
 
     private TypeFragment getFragment() {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ConfigDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ConfigDialog.java
@@ -104,13 +104,13 @@ public class ConfigDialog {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("h")) {
+        if (append && "h".equalsIgnoreCase(s)) {
             append = false;
             binding.url.append("ttp://");
-        } else if (append && s.equalsIgnoreCase("f")) {
+        } else if (append && "f".equalsIgnoreCase(s)) {
             append = false;
             binding.url.append("ile://");
-        } else if (append && s.equalsIgnoreCase("a")) {
+        } else if (append && "a".equalsIgnoreCase(s)) {
             append = false;
             binding.url.append("ssets://");
         } else if (s.length() > 1) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ProxyDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/ProxyDialog.java
@@ -64,10 +64,10 @@ public class ProxyDialog {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("h")) {
+        if (append && "h".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ttp://");
-        } else if (append && s.equalsIgnoreCase("s")) {
+        } else if (append && "s".equalsIgnoreCase(s)) {
             append = false;
             binding.text.append("ocks5://");
         } else if (append && s.length() == 1) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/UaDialog.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/dialog/UaDialog.java
@@ -65,10 +65,10 @@ public class UaDialog {
     }
 
     private void detect(String s) {
-        if (append && s.equalsIgnoreCase("c")) {
+        if (append && "c".equalsIgnoreCase(s)) {
             append = false;
             binding.text.setText(Util.CHROME);
-        } else if (append && s.equalsIgnoreCase("o")) {
+        } else if (append && "o".equalsIgnoreCase(s)) {
             append = false;
             binding.text.setText(okhttp3.internal.Util.userAgent);
         } else if (s.length() > 1) {

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/TypeFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/TypeFragment.java
@@ -78,7 +78,7 @@ public class TypeFragment extends BaseFragment implements CustomScroller.Callbac
     }
 
     private boolean isHome() {
-        return getTypeId().equals("home");
+        return "home".equals(getTypeId());
     }
 
     private Site getSite() {
@@ -141,9 +141,9 @@ public class TypeFragment extends BaseFragment implements CustomScroller.Callbac
     }
 
     private void getVideo(String typeId, String page) {
-        if (page.equals("1")) mAdapter.clear();
-        if (page.equals("1") && !mBinding.swipeLayout.isRefreshing()) mBinding.progressLayout.showProgress();
-        if (isHome() && page.equals("1")) setAdapter(getParent().getResult());
+        if ("1".equals(page)) mAdapter.clear();
+        if ("1".equals(page) && !mBinding.swipeLayout.isRefreshing()) mBinding.progressLayout.showProgress();
+        if (isHome() && "1".equals(page)) setAdapter(getParent().getResult());
         else mViewModel.categoryContent(getKey(), typeId, page, true, mExtends);
     }
 

--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
@@ -313,7 +313,7 @@ public class VodFragment extends BaseFragment implements SiteCallback, FilterCal
         @Override
         public Fragment getItem(int position) {
             Class type = mAdapter.get(position);
-            return TypeFragment.newInstance(getSite().getKey(), type.getTypeId(), type.getStyle(), type.getExtend(true), type.getTypeFlag().equals("1"));
+            return TypeFragment.newInstance(getSite().getKey(), type.getTypeId(), type.getStyle(), type.getExtend(true), "1".equals(type.getTypeFlag()));
         }
 
         @Override

--- a/catvod/src/main/java/com/github/catvod/net/interceptor/DefaultInterceptor.java
+++ b/catvod/src/main/java/com/github/catvod/net/interceptor/DefaultInterceptor.java
@@ -27,7 +27,7 @@ public class DefaultInterceptor implements Interceptor {
     public Response intercept(@NonNull Chain chain) throws IOException {
         Response response = chain.proceed(getRequest(chain.request()));
         String encoding = response.header(HttpHeaders.CONTENT_ENCODING);
-        if (response.body() == null || encoding == null || !encoding.equals("deflate")) return response;
+        if (response.body() == null || encoding == null || !"deflate".equals(encoding)) return response;
         InflaterInputStream is = new InflaterInputStream(response.body().byteStream(), new Inflater(true));
         return response.newBuilder().headers(response.headers()).body(new ResponseBody() {
             @Nullable

--- a/catvod/src/main/java/com/github/catvod/utils/Trans.java
+++ b/catvod/src/main/java/com/github/catvod/utils/Trans.java
@@ -23,7 +23,7 @@ public class Trans {
     private Trans() {
         s2t = new HashMap<>();
         t2s = new HashMap<>();
-        trans = Locale.getDefault().getCountry().equals("TW");
+        trans = "TW".equals(Locale.getDefault().getCountry());
         if (trans) init();
     }
 

--- a/forcetech/src/main/java/com/forcetech/Util.java
+++ b/forcetech/src/main/java/com/forcetech/Util.java
@@ -29,7 +29,7 @@ public class Util {
 
     public static String scheme(String url) {
         String scheme = Uri.parse(url).getScheme();
-        if (scheme.equals("P2p")) scheme = "mitv";
+        if ("P2p".equals(scheme)) scheme = "mitv";
         return scheme.toLowerCase();
     }
 

--- a/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/IjkMediaMeta.java
+++ b/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/IjkMediaMeta.java
@@ -176,14 +176,14 @@ public class IjkMediaMeta {
 
     private static String convertLang(String text) {
         if (text == null) return null;
-        if (text.equals("chi")) return "zh";
-        if (text.equals("cze")) return "cs";
-        if (text.equals("dut")) return "nl";
-        if (text.equals("fre")) return "fr";
-        if (text.equals("ger")) return "de";
-        if (text.equals("gre")) return "el";
-        if (text.equals("ice")) return "is";
-        if (text.equals("rum")) return "ro";
+        if ("chi".equals(text)) return "zh";
+        if ("cze".equals(text)) return "cs";
+        if ("dut".equals(text)) return "nl";
+        if ("fre".equals(text)) return "fr";
+        if ("ger".equals(text)) return "de";
+        if ("gre".equals(text)) return "el";
+        if ("ice".equals(text)) return "is";
+        if ("rum".equals(text)) return "ro";
         return text;
     }
 
@@ -217,7 +217,7 @@ public class IjkMediaMeta {
             streamMeta.mCodecLongName = streamMeta.getString(IJKM_KEY_CODEC_LONG_NAME);
             streamMeta.mBitrate = streamMeta.getInt(IJKM_KEY_BITRATE);
 
-            if (streamMeta.mType.equalsIgnoreCase(IJKM_VAL_TYPE__VIDEO)) {
+            if (IJKM_VAL_TYPE__VIDEO.equalsIgnoreCase(streamMeta.mType)) {
                 streamMeta.mWidth = streamMeta.getInt(IJKM_KEY_WIDTH);
                 streamMeta.mHeight = streamMeta.getInt(IJKM_KEY_HEIGHT);
                 streamMeta.mFpsNum = streamMeta.getInt(IJKM_KEY_FPS_NUM);
@@ -226,7 +226,7 @@ public class IjkMediaMeta {
                 streamMeta.mTbrDen = streamMeta.getInt(IJKM_KEY_TBR_DEN);
                 streamMeta.mSarNum = streamMeta.getInt(IJKM_KEY_SAR_NUM);
                 streamMeta.mSarDen = streamMeta.getInt(IJKM_KEY_SAR_DEN);
-            } else if (streamMeta.mType.equalsIgnoreCase(IJKM_VAL_TYPE__AUDIO)) {
+            } else if (IJKM_VAL_TYPE__AUDIO.equalsIgnoreCase(streamMeta.mType)) {
                 streamMeta.mSampleRate = streamMeta.getInt(IJKM_KEY_SAMPLE_RATE);
                 streamMeta.mChannelLayout = streamMeta.getLong(IJKM_KEY_CHANNEL_LAYOUT);
             }

--- a/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/misc/IjkMediaFormat.java
+++ b/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/misc/IjkMediaFormat.java
@@ -175,7 +175,7 @@ public class IjkMediaFormat implements IMediaFormat {
                 sb.append(profile);
 
                 String codecName = mediaFormat.getString(IjkMediaMeta.IJKM_KEY_CODEC_NAME);
-                if (!TextUtils.isEmpty(codecName) && codecName.equalsIgnoreCase(CODEC_NAME_H264)) {
+                if (!TextUtils.isEmpty(codecName) && CODEC_NAME_H264.equalsIgnoreCase(codecName)) {
                     int level = mediaFormat.getInteger(IjkMediaMeta.IJKM_KEY_CODEC_LEVEL);
                     if (level < 10)
                         return sb.toString();

--- a/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/ui/IjkVideoView.java
+++ b/ijkplayer/src/main/java/tv/danmaku/ijk/media/player/ui/IjkVideoView.java
@@ -411,7 +411,7 @@ public class IjkVideoView extends FrameLayout implements MediaController.MediaPl
         for (int index = 0; index < trackInfos.size(); index++) {
             ITrackInfo trackInfo = trackInfos.get(index);
             if (trackInfo.getTrackType() != ITrackInfo.MEDIA_TRACK_TYPE_TEXT) continue;
-            if (trackInfo.getLanguage().equals("zh") && index != selected) {
+            if ("zh".equals(trackInfo.getLanguage()) && index != selected) {
                 mPlayer.selectTrack(index);
                 break;
             }

--- a/quickjs/src/main/java/com/fongmi/quickjs/utils/Connect.java
+++ b/quickjs/src/main/java/com/fongmi/quickjs/utils/Connect.java
@@ -65,9 +65,9 @@ public class Connect {
     }
 
     private static RequestBody getPostBody(Req req, String contentType) {
-        if (req.getData() != null && req.getPostType().equals("json")) return getJsonBody(req);
-        if (req.getData() != null && req.getPostType().equals("form")) return getFormBody(req);
-        if (req.getData() != null && req.getPostType().equals("form-data")) return getFormDataBody(req);
+        if (req.getData() != null && "json".equals(req.getPostType())) return getJsonBody(req);
+        if (req.getData() != null && "form".equals(req.getPostType())) return getFormBody(req);
+        if (req.getData() != null && "form-data".equals(req.getPostType())) return getFormDataBody(req);
         if (req.getBody() != null && contentType != null) return RequestBody.create(req.getBody(), MediaType.get(contentType));
         return RequestBody.create("", null);
     }

--- a/quickjs/src/main/java/com/fongmi/quickjs/utils/Parser.java
+++ b/quickjs/src/main/java/com/fongmi/quickjs/utils/Parser.java
@@ -117,9 +117,9 @@ public class Parser {
 
     public String pdfh(String html, String rule, String addUrl) {
         Document doc = cache.getPdfh(html);
-        if (rule.equals("body&&Text") || rule.equals("Text")) {
+        if ("body&&Text".equals(rule) || "Text".equals(rule)) {
             return doc.text();
-        } else if (rule.equals("body&&Html") || rule.equals("Html")) {
+        } else if ("body&&Html".equals(rule) || "Html".equals(rule)) {
             return doc.html();
         }
         String option = "";
@@ -138,9 +138,9 @@ public class Parser {
             if (elements.isEmpty()) return "";
         }
         if (TextUtils.isEmpty(option)) return elements.outerHtml();
-        if (option.equals("Text")) {
+        if ("Text".equals(option)) {
             return elements.text();
-        } else if (option.equals("Html")) {
+        } else if ("Html".equals(option)) {
             return elements.html();
         } else {
             String result = elements.attr(option);


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [http://cwe.mitre.org/data/definitions/476.html](http://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FTV%7C8390a4aaad17962634aac0150f5c34573a64ea5f)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->