### PR TITLE
Introduced protections against predictable RNG abuse

### DIFF
--- a/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
+++ b/app/src/mobile/java/com/fongmi/android/tv/ui/fragment/VodFragment.java
@@ -54,6 +54,7 @@ import com.github.catvod.net.OkHttp;
 import com.github.catvod.utils.Trans;
 import com.google.common.net.HttpHeaders;
 import com.permissionx.guolindev.PermissionX;
+import java.security.SecureRandom;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -161,7 +162,7 @@ public class VodFragment extends BaseFragment implements SiteCallback, FilterCal
     private void updateHot() {
         App.post(mRunnable, 10 * 1000);
         if (mHots.isEmpty() || mHots.size() < 10) return;
-        mBinding.hot.setText(mHots.get(new Random().nextInt(11)));
+        mBinding.hot.setText(mHots.get(new SecureRandom().nextInt(11)));
     }
 
     private Result handle(Result result) {

--- a/quickjs/src/main/java/com/fongmi/quickjs/utils/Connect.java
+++ b/quickjs/src/main/java/com/fongmi/quickjs/utils/Connect.java
@@ -7,6 +7,7 @@ import com.github.catvod.utils.Util;
 import com.google.common.net.HttpHeaders;
 import com.whl.quickjs.wrapper.JSObject;
 import com.whl.quickjs.wrapper.QuickJSContext;
+import java.security.SecureRandom;
 
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class Connect {
     }
 
     private static RequestBody getFormDataBody(Req req) {
-        String boundary = "--dio-boundary-" + new Random().nextInt(42949) + "" + new Random().nextInt(67296);
+        String boundary = "--dio-boundary-" + new SecureRandom().nextInt(42949) + "" + new SecureRandom().nextInt(67296);
         MultipartBody.Builder builder = new MultipartBody.Builder(boundary).setType(MultipartBody.FORM);
         Map<String, String> params = Json.toMap(req.getData());
         for (String key : params.keySet()) builder.addFormDataPart(key, params.get(key));

--- a/thunder/src/main/java/com/xunlei/downloadlib/android/XLUtil.java
+++ b/thunder/src/main/java/com/xunlei/downloadlib/android/XLUtil.java
@@ -1,6 +1,7 @@
 package com.xunlei.downloadlib.android;
 
 import android.util.Base64;
+import java.security.SecureRandom;
 
 import java.util.Random;
 import java.util.UUID;
@@ -22,7 +23,7 @@ public class XLUtil {
     }
 
     private static String random(String base, int length) {
-        Random random = new Random();
+        Random random = new SecureRandom();
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < length; i++) sb.append(base.charAt(random.nextInt(base.length())));
         return sb.toString();


### PR DESCRIPTION
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/secure-random](https://docs.pixee.ai/codemods/java/pixee_java_secure-random)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FTV%7Cd70d9a07e68356b218c8bc5dc8a690c2becc7382)

<!--{"type":"DRIP","codemod":"pixee:java/secure-random"}-->