### PR TITLE
Future 20240529 epg diyp

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/api/LiveParser.java
+++ b/app/src/main/java/com/fongmi/android/tv/api/LiveParser.java
@@ -26,6 +26,7 @@ public class LiveParser {
 
     private static final Pattern CATCHUP_SOURCE = Pattern.compile(".*catchup-source=\"(.?|.+?)\".*");
     private static final Pattern CATCHUP = Pattern.compile(".*catchup=\"(.?|.+?)\".*");
+    private static final Pattern TVG_NAME = Pattern.compile(".*tvg-name=\"(.?|.+?)\".*");
     private static final Pattern GROUP = Pattern.compile(".*group-title=\"(.?|.+?)\".*");
     private static final Pattern LOGO = Pattern.compile(".*tvg-logo=\"(.?|.+?)\".*");
     private static final Pattern NAME = Pattern.compile(".*,(.+?)$");
@@ -67,19 +68,24 @@ public class LiveParser {
 
     private static void m3u(Live live, String text) {
         Setting setting = Setting.create();
-        Catchup catchup = Catchup.create();
+//        Catchup catchup = Catchup.create();
         Channel channel = Channel.create("");
         for (String line : text.split("\n")) {
             if (Thread.interrupted()) break;
             if (setting.find(line)) {
                 setting.check(line);
             } else if (line.startsWith("#EXTM3U")) {
-                catchup.setType(extract(line, CATCHUP));
-                catchup.setSource(extract(line, CATCHUP_SOURCE));
+
             } else if (line.startsWith("#EXTINF:")) {
                 Group group = live.find(Group.create(extract(line, GROUP), live.isPass()));
                 channel = group.find(Channel.create(extract(line, NAME)));
                 channel.setLogo(extract(line, LOGO));
+                channel.setTvgname(extract(line, TVG_NAME));
+                Catchup catchup = Catchup.create();
+                catchup.setType(extract(line, CATCHUP));
+                catchup.setSource(extract(line, CATCHUP_SOURCE));
+
+
                 channel.setCatchup(catchup);
             } else if (!line.startsWith("#") && line.contains("://")) {
                 String[] split = line.split("\\|");

--- a/app/src/main/java/com/fongmi/android/tv/bean/Channel.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Channel.java
@@ -13,11 +13,7 @@ import com.google.common.net.HttpHeaders;
 import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 public class Channel {
 
@@ -31,6 +27,8 @@ public class Channel {
     private String epg;
     @SerializedName("name")
     private String name;
+    @SerializedName("tvgname")
+    private String tvgname;
     @SerializedName("ua")
     private String ua;
     @SerializedName("click")
@@ -326,8 +324,14 @@ public class Channel {
         if (!live.getCatchup().isEmpty() && getCatchup().isEmpty()) setCatchup(live.getCatchup());
         if (live.getReferer().length() > 0 && getReferer().isEmpty()) setReferer(live.getReferer());
         if (live.getPlayerType() != -1 && getPlayerType() == -1) setPlayerType(live.getPlayerType());
-        if (!getEpg().startsWith("http")) setEpg(live.getEpg().replace("{name}", getName()).replace("{epg}", getEpg()));
-        if (!getLogo().startsWith("http")) setLogo(live.getLogo().replace("{name}", getName()).replace("{logo}", getLogo()));
+        // 优先使用tvgname
+        String tvg_name = getTvgname();
+        if (Objects.equals(tvg_name, "")){
+            tvg_name = getName();
+        }
+
+        if (!getEpg().startsWith("http")) setEpg(live.getEpg().replace("{name}", tvg_name ).replace("{epg}", getEpg()));
+        if (!getLogo().startsWith("http")) setLogo(live.getLogo().replace("{name}", tvg_name).replace("{logo}", getLogo()));
     }
 
     public void setLine(String line) {
@@ -358,6 +362,7 @@ public class Channel {
         setDrm(item.getDrm());
         setEpg(item.getEpg());
         setUa(item.getUa());
+        setTvgname(item.getTvgname());
         return this;
     }
 
@@ -375,5 +380,13 @@ public class Channel {
         if (!(obj instanceof Channel)) return false;
         Channel it = (Channel) obj;
         return getName().equals(it.getName()) || (!getNumber().isEmpty() && getNumber().equals(it.getNumber()));
+    }
+
+    public String getTvgname() {
+        return tvgname;
+    }
+
+    public void setTvgname(String tvgname) {
+        this.tvgname = tvgname;
     }
 }

--- a/app/src/main/java/com/fongmi/android/tv/bean/Epg.java
+++ b/app/src/main/java/com/fongmi/android/tv/bean/Epg.java
@@ -2,20 +2,20 @@ package com.fongmi.android.tv.bean;
 
 import android.text.TextUtils;
 
+import android.util.Log;
 import com.fongmi.android.tv.App;
+import com.fongmi.android.tv.model.LiveViewModel;
 import com.fongmi.android.tv.utils.Util;
 import com.github.catvod.utils.Trans;
 import com.google.gson.annotations.SerializedName;
+import android.util.Log;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 
 public class Epg {
-
-    @SerializedName("key")
+    private final static String TAG = Epg.class.getName();
+    @SerializedName("channel_name")
     private String key;
     @SerializedName("date")
     private String date;
@@ -26,6 +26,8 @@ public class Epg {
 
     public static Epg objectFrom(String str, String key, SimpleDateFormat format) {
         try {
+            Log.d(TAG, String.format(Locale.US, "objectFrom: str=%s, key=%s", str, key));
+
             Epg item = App.gson().fromJson(str, Epg.class);
             item.setTime(format);
             item.setKey(key);


### PR DESCRIPTION
1.解析m3u8时,增加tvg-name的解析,同时修正catchup和catchup-source的获取
2.修正EPG的json key,常用的epg接口的关键字是channel_name
3.rpc获取epg信息和logo信息时,优先使用tvg-name(如果有设置),没有tvg-name再使用name去获取.
4.catchup实现 default 模式,可以支持直播时用组播源,回看时用rtsp源. 
#EXTINF:-1  catchup="default" catchup-source="rtsp://xxxx
?aaaa=bbb&playseek=${(b)yyyyMMddHHmmss}-${(e)yyyyMMddHHmmss}"  tvg-id="1",CC
http://192.168.100.1:5146/udp/1.2.3.4:5146
catchup=append时 兼容 ?playseek和 &playseek