### PR TITLE
m3u新增正則規則

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/api/LiveParser.java
+++ b/app/src/main/java/com/fongmi/android/tv/api/LiveParser.java
@@ -30,7 +30,7 @@ public class LiveParser {
     private static final Pattern URL_TVG = Pattern.compile(".*url-tvg=\"(.?|.+?)\".*");
     private static final Pattern GROUP = Pattern.compile(".*group-title=\"(.?|.+?)\".*");
     private static final Pattern NAME = Pattern.compile(".*,(.+?)$");
-    private static final Pattern M3U = Pattern.compile("#EXTM3U|#EXTINF");
+    private static final Pattern M3U = Pattern.compile("^(?!.*#genre#)(#EXTM3U|#EXTINF)");
 
     private static String extract(String line, Pattern pattern) {
         Matcher matcher = pattern.matcher(line.trim());


### PR DESCRIPTION
在部分直播連接中，EXTINF是屬於url的一部分。 會將text類型的直播檔案錯誤匹配成m3u進行解析，導致直播解析錯誤沒有頻道