### PR TITLE
remove spider okhttp cookie

### DIFF
--- a/catvod/src/main/java/com/github/catvod/crawler/Spider.java
+++ b/catvod/src/main/java/com/github/catvod/crawler/Spider.java
@@ -76,6 +76,6 @@ public abstract class Spider {
     }
 
     public static OkHttpClient client() {
-        return OkHttp.client();
+        return OkHttp.client().newBuilder().cookieJar(null).build();
     }
 }

--- a/catvod/src/main/java/com/github/catvod/crawler/Spider.java
+++ b/catvod/src/main/java/com/github/catvod/crawler/Spider.java
@@ -75,7 +75,16 @@ public abstract class Spider {
         return OkHttp.dns();
     }
 
+    private static volatile OkHttpClient spiderClient;
+
     public static OkHttpClient client() {
-        return OkHttp.client().newBuilder().cookieJar(null).build();
+        if (spiderClient == null) {
+            synchronized (Spider.class) {
+                if (spiderClient == null) {
+                    spiderClient = OkHttp.client().newBuilder().cookieJar(null).build();
+                }
+            }
+        }
+        return spiderClient;
     }
 }


### PR DESCRIPTION
spider的cookie不應該由殼子統一管理，會導致未知錯誤。

問題描述：https://github.com/WoKee/TV/pull/1#issue-3535272040