### PR TITLE
fix(quickjs): 修复JS爬虫初始化时的线程和空指针问题

### DIFF
--- a/quickjs/src/main/java/com/fongmi/quickjs/crawler/Spider.java
+++ b/quickjs/src/main/java/com/fongmi/quickjs/crawler/Spider.java
@@ -59,7 +59,7 @@ public class Spider extends com.github.catvod.crawler.Spider {
     public void init(Context context, String extend) throws Exception {
         initializeJS();
         if (cat) call("init", submit(() -> cfg(extend)).get());
-        else call("init", Json.isObj(extend) ? ctx.parse(extend) : extend);
+        else call("init", Json.isObj(extend) ? submit(() -> ctx.parse(extend)).get() : extend);
     }
 
     @Override
@@ -179,6 +179,7 @@ public class Spider extends com.github.catvod.crawler.Spider {
     private void createFun() {
         try {
             Global.create(ctx, executor);
+            if (dex == null) return;
             Class<?> clz = dex.loadClass("com.github.catvod.js.Function");
             clz.getDeclaredConstructor(QuickJSContext.class).newInstance(ctx);
         } catch (Throwable e) {


### PR DESCRIPTION
对`quickjs/src/main/java/com/fongmi/quickjs/crawler/Spider.java`进行了两处修改：

1. 修复了在`init`方法中解析`ext`参数时可能出现的`QuickJSException: Must be call same thread`异常。通过将`ctx.parse(extend)`调用移至`submit()`中，确保其在正确的线程执行。

2. 在`createFun`方法中增加了对`dex`对象的空指针检查，避免了在配置文件中未提供`jar`时引发的`NullPointerException`。