### PR TITLE
Fix Surface decoder fallback on background

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -374,12 +374,15 @@ public class PlayerManager implements ParseCallback {
     }
 
     public void toggleDecode() {
+        long position = getPosition();
+        boolean playWhenReady = player.getPlayWhenReady();
         decode = isHard() ? PlayerEngine.SOFT : PlayerEngine.HARD;
         boolean rebuild = engine.setDecode(decode);
         callback.onDecodeChanged();
         if (!rebuild) return;
         setPlayer(engine.rebuild());
-        startCurrent(getPosition());
+        startCurrent(position);
+        if (!playWhenReady) player.pause();
     }
 
     private void handleDecodeError(PlaybackException e) {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
@@ -537,7 +537,9 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
     @Override
     protected void onPause() {
         super.onPause();
-        if (isRedirect() && mController != null) mController.pause();
+        boolean shouldPause = isRedirect() || (isOwner() && PlayerSetting.isBackgroundOff());
+        if (shouldPause && mController != null) mController.pause();
+        if (shouldPause && !isInPictureInPictureMode() && PlayerSetting.getRender() == PlayerSetting.RENDER_SURFACE) detachSurface();
     }
 
     @Override


### PR DESCRIPTION
## Summary

- pause playback before a background transition when background playback is disabled
- detach the `SurfaceView` output before the window surface is destroyed, while leaving TextureView, background playback, and PiP behavior unchanged
- preserve playback position and `playWhenReady` when rebuilding the player for a decoder switch

## Problem

On some Android TV devices, including Xiaomi TVs, hiding a paused `SurfaceView` can invalidate the output surface while the hardware `MediaCodec` still owns it. The codec then reports a decoding failure, which triggers the software-decoder fallback.

The fallback previously rebuilt the player from the new player's position and always resumed playback. As a result, a paused video could show the hardware-decoding failure notification, restart from the wrong position, and continue playing in the background.

## Testing

- `git diff --check`
- Gradle compile not run: this checkout does not contain the required `local.properties`, Android SDK configuration, or ignored `lib-*.aar` playback dependencies

