### PR TITLE
修复 Surface 模式进入后台时硬解失败

### DIFF
--- a/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
+++ b/app/src/main/java/com/fongmi/android/tv/player/PlayerManager.java
@@ -53,6 +53,7 @@ public class PlayerManager implements ParseCallback {
     private DanmakuConfig danmakuConfig;
     private long pendingStartPositionMs;
     private boolean danmakuEnabled;
+    private boolean surfaceSuspended;
     private boolean initTrack;
     private int retry;
     private int decode;
@@ -310,10 +311,27 @@ public class PlayerManager implements ParseCallback {
     }
 
     public void play() {
+        resumeAfterSurfaceLoss();
         player.play();
     }
 
     public void pause() {
+        player.pause();
+    }
+
+    public void suspendForSurfaceLoss() {
+        if (surfaceSuspended) return;
+        surfaceSuspended = true;
+        App.removeCallbacks(runnable);
+        player.pause();
+        engine.stop();
+    }
+
+    public void resumeAfterSurfaceLoss() {
+        if (!surfaceSuspended) return;
+        surfaceSuspended = false;
+        if (player.getCurrentMediaItem() == null) return;
+        player.prepare();
         player.pause();
     }
 
@@ -374,15 +392,22 @@ public class PlayerManager implements ParseCallback {
     }
 
     public void toggleDecode() {
+        long position = getPosition();
+        boolean playWhenReady = player.getPlayWhenReady();
         decode = isHard() ? PlayerEngine.SOFT : PlayerEngine.HARD;
         boolean rebuild = engine.setDecode(decode);
         callback.onDecodeChanged();
         if (!rebuild) return;
         setPlayer(engine.rebuild());
-        startCurrent(getPosition());
+        startCurrent(position);
+        if (!playWhenReady) player.pause();
     }
 
     private void handleDecodeError(PlaybackException e) {
+        if (surfaceSuspended || !player.getPlayWhenReady()) {
+            suspendForSurfaceLoss();
+            return;
+        }
         if (++retry > 1) {
             callback.onError(engine.getErrorMessage(e));
         } else {

--- a/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
+++ b/app/src/main/java/com/fongmi/android/tv/ui/activity/PlaybackActivity.java
@@ -531,19 +531,31 @@ public abstract class PlaybackActivity extends BaseActivity implements MediaCont
             onReclaim();
         } else {
             attachSurface();
+            if (ownsPlaybackSurface()) player().resumeAfterSurfaceLoss();
         }
+    }
+
+    private boolean ownsPlaybackSurface() {
+        return mService != null && getPlayerView().getPlayer() == player().getPlayer();
     }
 
     @Override
     protected void onPause() {
+        boolean ownsSurface = ownsPlaybackSurface();
+        boolean backgroundOff = PlayerSetting.isBackgroundOff();
+        boolean shouldPause = isRedirect() || (ownsSurface && backgroundOff);
+        boolean shouldSuspendSurface = shouldPause && ownsSurface && !isInPictureInPictureMode() && PlayerSetting.getRender() == PlayerSetting.RENDER_SURFACE;
+        if (shouldSuspendSurface) player().suspendForSurfaceLoss();
+        else if (shouldPause && ownsSurface) player().pause();
+        else if (shouldPause && mController != null) mController.pause();
+        if (shouldSuspendSurface) detachSurface();
         super.onPause();
-        if (isRedirect() && mController != null) mController.pause();
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        if (isOwner() && PlayerSetting.isBackgroundOff() && mController != null) mController.pause();
+        if (mService != null && isOwner() && PlayerSetting.isBackgroundOff()) player().pause();
     }
 
     @Override


### PR DESCRIPTION
## 问题说明

部分小米电视使用 SurfaceView 和 MediaCodec 硬解播放时，返回电视桌面或触发屏幕保护会销毁播放 Surface。

播放器原来只执行 pause 和解绑 Surface，但 pause 不会释放仍处于 STARTED 状态的硬解码器。Surface 被系统回收后，厂商解码器 OMX.MS.AVC.Decoder 会报 0x80001013，随后 Media3 将其识别为解码失败，应用自动切换软解，并可能恢复播放。

## 修改内容

1. 后台播放关闭、使用 Surface 渲染且非画中画时，在解绑 Surface 之前主动暂停并停止播放器，确保硬解码器先释放。
2. 使用 PlayerView 实际绑定的 Player 判断当前页面是否持有播放 Surface，避免业务 owner 状态与 Surface 生命周期不同步。
3. 返回应用并重新绑定 Surface 后调用 prepare 重新创建硬解码器，同时保持暂停状态和原播放进度。
4. Surface 暂停期间出现的延迟解码错误不再触发软解降级。
5. 重建软硬解播放器前保存播放进度和 playWhenReady 状态，避免原本暂停的视频在重建后自动播放。

## 影响范围

该逻辑只在以下条件下生效：

- 后台播放关闭
- 使用 Surface 渲染
- 非画中画模式

不会改变 Texture 渲染、正常前台播放和后台播放开启时的原有行为。

## 测试结果

在小米电视上使用 Surface 硬解测试：

- 播放中返回桌面：不再提示硬解失败或切换软解
- 暂停后返回桌面：不再提示硬解失败或后台播放
- 暂停期间触发屏保：不再触发硬解失败
- 返回应用：重新准备播放器，保留原播放进度并保持暂停
