### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [討論群組](https://t.me/fongmi_official) | [發布頻道](https://t.me/fongmi_release)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=FongMi/TV&type=Date)](https://www.star-history.com/#FongMi/TV&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=FongMi/TV&type=Date)](https://star-history.dera.page/#FongMi/TV&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer API is restricted. This change points the chart to star-history.dera.page, an alternative that uses a different data source and requires no API token, so the chart renders correctly again.